### PR TITLE
Update AddBikeParkingCapacity.kt to exclude bicycle_parking=informal

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/bike_parking_capacity/AddBikeParkingCapacity.kt
@@ -17,6 +17,7 @@ class AddBikeParkingCapacity : OsmFilterQuestType<Int>() {
          amenity = bicycle_parking
          and access !~ private|no
          and bicycle_parking !~ floor
+         and bicycle_parking !~ informal
          and (
            !capacity
            or bicycle_parking ~ stands|wall_loops and capacity older today -4 years


### PR DESCRIPTION
Users created notes because they could not assess capacity for informal bicycle stands (e.g. long metal bar, street furniture or fences).

Purpose of this pull request: if a device has "bicycle_parking=informal", the quest will not show up.